### PR TITLE
Always show scrollbar when scrolling with mouse button down

### DIFF
--- a/assets/ng-scrollable.css
+++ b/assets/ng-scrollable.css
@@ -46,6 +46,10 @@
     opacity: 1;
 }
 
+.scrollable.active .scrollable-bar {
+    opacity: 1;
+}
+
 .scrollable .scrollable-slider {
     -webkit-border-radius: 2px;
        -moz-border-radius: 2px;


### PR DESCRIPTION
Currently, the scrollbar disappears when the mouse leaves the scrollable zone, even if the user has "pressed" the scrollbar.
This commit makes the scrollbar always visible when the user is scrolling and holding the mouse button down.