### PR TITLE
Fixed refresh() bugs

### DIFF
--- a/src/ng-scrollable.js
+++ b/src/ng-scrollable.js
@@ -248,16 +248,16 @@ angular.module('ngScrollable', [])
             isXActive = true;
           }
           else {
-            isXActive = false;
             scrollX(0);
+            isXActive = false;
           }
 
           if (config.scrollY !== 'none' && containerHeight + config.scrollYSlackSpace < contentHeight) {
             isYActive = true;
           }
           else {
-            isYActive = false;
             scrollY(0);
+            isYActive = false;
           }
 
           // update UI
@@ -265,9 +265,17 @@ angular.module('ngScrollable', [])
           updateBarY();
           updateSliderX();
           updateSliderY();
+          
+          // make sure scroll position isn't beyond content bounds
+          if (contentWidth < contentLeft + xSliderLeft + xSliderWidth) {
+            scrollX(xSliderLeft);
+          }
+          if (contentHeight < contentTop + ySliderTop + ySliderHeight) {
+            scrollY(ySliderTop);
+          }
 
           // broadcast the new dimensions down the scope stack so inner content
-          // controllers can react appropriatly
+          // controllers can react appropriately
           if (!noNotify) {
             $scope.$broadcast('scrollable.dimensions', containerWidth, containerHeight, contentWidth, contentHeight, config.id);
           }


### PR DESCRIPTION
Fixed: Inactive scrollbars didn't scroll to position 0 as intended.
Fixed: Container scroll position could be outside content bounds.

Encountered these bugs when container was scrolled near bottom of content & then content was shortened by an ng-repeat filter. ContentHeight updated, but translate3d property didn't update accordingly, so the container's view was scrolled past the bottom of the content.