### PR TITLE
Added sanity check for over object type as SVG's return objects

### DIFF
--- a/src/ng-scrollable.js
+++ b/src/ng-scrollable.js
@@ -565,7 +565,7 @@ angular.module('ngScrollable', [])
 
           // default scroll inside explicitly marked containers
           while (over) {
-            if (over.className && typeof(over) === 'string' && over.className.indexOf('scrollable-ignore') > -1) {
+            if (over.className && typeof(over.className) === 'string' && over.className.indexOf('scrollable-ignore') > -1) {
               return true;
             }
             over = over.parentNode;

--- a/src/ng-scrollable.js
+++ b/src/ng-scrollable.js
@@ -565,7 +565,7 @@ angular.module('ngScrollable', [])
 
           // default scroll inside explicitly marked containers
           while (over) {
-            if (over.className && over.className.indexOf('scrollable-ignore') > -1) {
+            if (over.className && typeof(over) === 'string' && over.className.indexOf('scrollable-ignore') > -1) {
               return true;
             }
             over = over.parentNode;


### PR DESCRIPTION
Had an issue using this plugin whereby a container the included an SVG graph couldn't scroll via the mouse wheel due to the fact that the over variable was an object and therefore the indexOf call was throwing an error.

Added sanity checking of the variable type to correct this.